### PR TITLE
Version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.4-fpm
+FROM php:7.2.5-fpm
 
 RUN apt-get update && apt-get install -y \
         apt-utils \


### PR DESCRIPTION
After re-building the web container, I was getting an issue with `symfony/filesystem v5.1.5` requiring `php >=7.2.5`, so this PR is to bump the php version just a bit to see if that fixes it. You can re-create this by temporarily removing the composer lock file and running composer install / update. 